### PR TITLE
Bump to node-elm-compiler 1.0.1 which supports Elm 0.16

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "elm-version": "0.15.0 <= v < 0.16.0",
+  "elm-version": "0.16.0 <= v < 0.17.0",
   "summary": "Test files for grunt-elm",
   "repository": "https://github.com/rtfeldman/grunt-elm.git",
   "license": "Apache2",
@@ -9,6 +9,6 @@
   ],
   "exposed-modules": [],
   "dependencies": {
-    "elm-lang/core": "2.0.0 <= v < 3.0.0"
+    "elm-lang/core": "3.0.0 <= v < 4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-elm",
   "description": "Compile Elm files to JavaScript. (Elm version 0.15)",
-  "version": "1.3.0+elm-0.15.1",
+  "version": "1.4.0+elm-0.16.0",
   "homepage": "https://github.com/rtfeldman/grunt-elm",
   "author": {
     "name": "Richard Feldman",
@@ -36,7 +36,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "node-elm-compiler": "0.4.0+elm-0.15.1",
+    "node-elm-compiler": "1.0.1",
     "lodash": "2.4.1"
   }
 }


### PR DESCRIPTION
Apparently node-elm-compiler@1.0.1 still supports Elm 0.15 but I wasn't able to get it to work without updating elm-package.json to use elm-version >= 0.16.