### PR TITLE
Pass options to grunt.util.spawn correctly

### DIFF
--- a/tasks/elm.js
+++ b/tasks/elm.js
@@ -14,12 +14,12 @@ module.exports = function(grunt) {
   });
 
   function compile(sources, options, spawnOptions, callback) {
-    function spawn(cmd, args) {
+    function spawn(cmd, args, options) {
       return grunt.util.spawn({
         cwd: process.cwd(),
         cmd: cmd,
         args: args,
-        options: spawnOptions
+        opts: _.merge(options, spawnOptions)
       }, function(err, result, exitCode) {
         // Log any stdout using grunt.log.ok and any stderr using grunt.log.error
         _.each({ok: result.stdout, error: result.stderr}, function(output, logType) {


### PR DESCRIPTION
`grunt.util.spawn` passes options to Node.js' `child_process#spawn` function via its `options.opts` argument. Currently, the code is incorrectly passing these options via the `options.options` argument. See the [docs](https://gruntjs.com/api/grunt.util#grunt.util.spawn).

In addition, `node-elm-compiler` passes its own options to the supplied `spawn` function, and these are currently ignored.

This commit addresses both of these issues.